### PR TITLE
Fix create_target.bat

### DIFF
--- a/devops/targets/create_target.bat
+++ b/devops/targets/create_target.bat
@@ -1,12 +1,12 @@
 @echo off
 
-del /q %TargetFilePath%
+del /q "%TargetFilePath%"
 
-for /f "tokens=*" %%a in (%TargetTemplateFilePath%) do (
+for /f "tokens=*" %%a in ("%TargetTemplateFilePath%") do (
      if %%a == NEW_LINE (
         echo.>>%TargetFilePath%
     ) else (
-        call echo %%a>>%TargetFilePath%
+        call echo %%a>>"%TargetFilePath%"
     )
 )
 


### PR DESCRIPTION
Bug fix for creating target file if path to SourceCodePath and TargetTemplateFilePath because of ProjectRoot directory has spaces.