### PR TITLE
Fix create_target.bat

### DIFF
--- a/devops/targets/create_target.bat
+++ b/devops/targets/create_target.bat
@@ -1,12 +1,12 @@
 @echo off
 
-del /q %TargetFilePath%
+del /q "%TargetFilePath%"
 
-for /f "tokens=*" %%a in (%TargetTemplateFilePath%) do (
+for /f "usebackq tokens=*" %%a in ("%TargetTemplateFilePath%") do (
      if %%a == NEW_LINE (
-        echo.>>%TargetFilePath%
+        echo.>>"%TargetFilePath%"
     ) else (
-        call echo %%a>>%TargetFilePath%
+        call echo %%a>>"%TargetFilePath%"
     )
 )
 


### PR DESCRIPTION
Handle spaces in the project path during targets creation